### PR TITLE
new operators: \BIAS, \corr, \Ebar, \Ehat, \Etilde, \SE, \SEtilde

### DIFF
--- a/statmath.sty
+++ b/statmath.sty
@@ -130,9 +130,16 @@
 \newcommand{\bfPsi}{\greekbf \Psi}
 \newcommand{\bfOmega}{\greekbf \Omega}
 \newcommand{\bfzero}{\greekbf 0}
+\DeclareMathOperator{\BIAS}{BIAS}
+\DeclareMathOperator{\corr}{corr}
 \DeclareMathOperator{\cov}{Cov}
 \DeclareMathOperator{\E}{E}
+\DeclareMathOperator{\Ebar}{\bar{E}}
+\DeclareMathOperator{\Ehat}{\hat{E}}
+\DeclareMathOperator{\Etilde}{\tilde{E}}
 \DeclareMathOperator{\MSE}{MSE}
+\DeclareMathOperator{\SE}{SE}
+\DeclareMathOperator{\SEtilde}{SEtilde}
 \DeclareMathOperator{\V}{V}
 \newcommand{\inas}{\overset{\scriptstyle a.s.}{\longrightarrow}}
 \newcommand{\indist}{\overset{\scriptstyle d}{\longrightarrow}}


### PR DESCRIPTION
Hello,

thanks for the package, I've been finding it quite useful. Here's a few more operators I've found myself using that aren't in the package yet: \BIAS (bias of an estimator), \corr (correlation of random variables), \Ebar, \Ehat and \Etilde (subjective expectations, used e.g. for bounded rationality in macroeconomic models), \SE (standard error) and \SEtilde (standard error under homoskedasticity).

Thanks for considering these for merging, and keep up the good work!