### PR TITLE
Add \inmsq, \aslim

### DIFF
--- a/statmath.dtx
+++ b/statmath.dtx
@@ -114,8 +114,12 @@
 % Convergence in probability: $X_n \inprob X$\\
 % \DescribeMacro{\indist}
 % Convergence in distribution: $X_n \indist X$\\
+% \DescribeMacro{\inmsq}
+% Convergence in mean square: $X_n \inmsq X$\\
 % \DescribeMacro{\plim}
 % Probability limit: $\plim X_n = X$\\
+% \DescribeMacro{\aslim}
+% Almost-sure limit: $\aslim X_n = X$\\
 % \DescribeMacro{\tr}
 % Trace of matrix: $\tr(\bfA)$\\
 % \DescribeMacro{\vc}
@@ -499,13 +503,19 @@
 %    \begin{macro}{\inas}
 %    \begin{macro}{\inprob}
 %    \begin{macro}{\indist}
+%    \begin{macro}{\inmsq}
 %    \begin{macro}{\plim}
+%    \begin{macro}{\aslim}
 %    \begin{macrocode}
 \newcommand{\inas}{\overset{\scriptstyle a.s.}{\longrightarrow}}
 \newcommand{\indist}{\overset{\scriptstyle d}{\longrightarrow}}
 \newcommand{\inprob}{\overset{\scriptstyle p}{\longrightarrow}}
+\newcommand{\inmsq}{\overset{\scriptstyle m}{\longrightarrow}}
 \DeclareMathOperator{\plim}{plim}
+\DeclareMathOperator{\aslim}{aslim}
 %    \end{macrocode}
+%    \end{macro}
+%    \end{macro}
 %    \end{macro}
 %    \end{macro}
 %    \end{macro}


### PR DESCRIPTION
Hello, here's two additional commands I'd like to suggest for the statmath package: `\inmsq` for mean square convergence, and `\aslim` as an alternate way of writing almost-sure convergence, akin to `\plim`. (I've remembered to edit the `dtx` file this time. ;))

Another note/suggestion: several authors seem to prefer writing almost-sure converge without the periods, i.e. as `\newcommand{\inas}{\overset{\scriptstyle as}{\longrightarrow}}`. Perhaps this could be accomodated by the package? I'm not sure how to best do this, however. The easiest way would be another new command (whatever that might be called); a better solution might be adding _two_ new versions of `\inas`, both unambiguously named, with `\inas` being an alias for the version with periods by default, and a package option to override this.

Thanks for considering both the merge and the suggestion, and thanks for the package as well (I'm still finding it very useful).